### PR TITLE
Fix document

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Motivations
 
-For the [https://github.com/samber/do](github.com/samber/do) project, I needed to convert a Go type into a string. I used to convert it with `fmt.Sprintf("%T", t)` -> `mypkg.MyStruct`, but it does not insert package path into type representation, leading to collision when package name and type match.
+For the [samber/do](https://github.com/samber/do) project, I needed to convert a Go type into a string. I used to convert it with `fmt.Sprintf("%T", t)` -> `mypkg.MyStruct`, but it does not insert package path into type representation, leading to collision when package name and type match.
 
 This package export type using the following representation:
 


### PR DESCRIPTION
https://github.com/samber/do in README.md is jumping to https://github.com/samber/go-type-to-string/blob/main/github.com/samber/do.
Fixed based on https://github.com/samber/do/blob/ca6ecee121da0e66a8bbca4b9392844ab7520cf7/README.md.