### PR TITLE
fix: handle anonymous structs

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -87,6 +87,29 @@ func getType(typeOfT reflect.Type) string {
 		default:
 			return fmt.Sprintf("func(%s) (%s)", in, strings.Join(out, ", "))
 		}
+	case reflect.Struct:
+		var builder strings.Builder
+		builder.WriteString("struct {")
+
+		for i := 0; i < typeOfT.NumField(); i++ {
+			if i > 0 {
+				builder.WriteString(";")
+			}
+			builder.WriteString(" ")
+			field := typeOfT.Field(i)
+			if !field.Anonymous {
+				builder.WriteString(field.Name)
+				builder.WriteString(" ")
+			}
+			builder.WriteString(getType(field.Type))
+		}
+
+		if typeOfT.NumField() > 0 {
+			builder.WriteString(" ")
+		}
+
+		builder.WriteString("}")
+		return builder.String()
 	default:
 		// any + interface{} + anonymous type
 		return typeOfT.String()

--- a/converter_test.go
+++ b/converter_test.go
@@ -205,9 +205,8 @@ func Test(t *testing.T) {
 		t, "func()")
 	check[struct{ foo int }](true,
 		t, "struct { foo int }")
-	// @TODO: fix this
-	// check[struct{ foo testStruct }](false,
-	// 	t, "struct { foo github.com/samber/go-type-to-string.testStruct }")
+	check[struct{ foo testStruct }](false,
+ 		t, "struct { foo github.com/samber/go-type-to-string.testStruct }")
 
 	// any
 	check[any](true,


### PR DESCRIPTION
Previously, the getType function would not correctly handle anonymous structs, causing tests to fail. This commit introduces a new case for reflect.Struct in the getType function, which correctly handles anonymous structs, including those with embedded fields.

The test case for this was uncommented and is now passing.